### PR TITLE
feat(config): make compression level configurable

### DIFF
--- a/crates/report/src/compress.rs
+++ b/crates/report/src/compress.rs
@@ -19,7 +19,9 @@ pub fn compress(path: impl AsRef<Path>, dest: impl AsRef<Path>) -> anyhow::Resul
 
     let input_file = File::open(path).expect("Failed to open input file");
     let output_file = File::create(&output_path).expect("Failed to create output file");
-    let mut encoder = ZlibEncoder::new(output_file, Compression::fast());
+    // Use compression level from config (0-9, where 0 is none and 9 is max)
+    let compression_level = CONFIG.get().compression_level;
+    let mut encoder = ZlibEncoder::new(output_file, Compression::new(compression_level));
     let mut reader = BufReader::new(input_file);
     copy(&mut reader, &mut encoder).expect("Zlib compression failed");
     encoder.finish().expect("Failed to finish Zlib compression");

--- a/crates/utils/src/config.rs
+++ b/crates/utils/src/config.rs
@@ -12,6 +12,9 @@ pub struct Config {
     pub tmp_dir: PathBuf,
     pub nix_config: PathBuf,
     pub problems_interface: String,
+    /// Compression level for zlib compression (0-9, where 0 is none and 9 is max)
+    /// Default is 1 (fast compression)
+    pub compression_level: u32,
 }
 
 impl Default for Config {
@@ -21,6 +24,7 @@ impl Default for Config {
             tmp_dir: PathBuf::from("/tmp/relago"),
             nix_config: PathBuf::from("/etc/nixos/xinux-config"),
             problems_interface: "org.freedesktop.problems.daemon".to_string(),
+            compression_level: 1, // Fast compression
         }
     }
 }

--- a/example-config.toml
+++ b/example-config.toml
@@ -1,0 +1,23 @@
+# Relago Configuration File
+# Copy this file to ./config.toml and customize as needed
+
+# Number of threads to use for parallel compression
+# Default: 4
+parallel_compression = 4
+
+# Compression level for zlib compression (0-9)
+# 0 = no compression, 1 = fast (default), 9 = maximum compression
+# Higher levels = smaller files but slower compression
+compression_level = 1
+
+# Temporary directory for reports
+# Default: /tmp/relago
+tmp_dir = "/tmp/relago"
+
+# Path to NixOS configuration directory
+# Default: /etc/nixos/xinux-config
+nix_config = "/etc/nixos/xinux-config"
+
+# D-Bus interface for problem reporting
+# Default: org.freedesktop.problems.daemon
+problems_interface = "org.freedesktop.problems.daemon"

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,31 @@
 
 System crash reporting and diagnostics tool for Linux.
 
+## Configuration
+
+Relago can be configured via a `config.toml` file in the current working directory. Copy the provided example:
+
+```bash
+cp config.toml.example config.toml
+```
+
+### Configuration Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `parallel_compression` | Number of threads for parallel compression | 4 |
+| `compression_level` | Zlib compression level (0-9) | 1 (fast) |
+| `tmp_dir` | Temporary directory for reports | /tmp/relago |
+| `nix_config` | Path to NixOS configuration | /etc/nixos/xinux-config |
+| `problems_interface` | D-Bus interface for problem reporting | org.freedesktop.problems.daemon |
+
+### Compression Level Guide
+
+- **0**: No compression (fastest)
+- **1**: Fast compression (default, recommended for most use cases)
+- **6**: Balanced compression
+- **9**: Maximum compression (slowest, smallest files)
+
 ## Commands
 
 ### Report Command


### PR DESCRIPTION
## Summary

This PR addresses issue #12 by making hardcoded compression values configurable.

## Changes

- Added `compression_level` field to Config struct (0-9, default 1 for fast compression)
- Updated `compress.rs` to use configurable compression level instead of hardcoded `Compression::fast()`
- Added `example-config.toml` with documentation for all configuration options
- Updated README with a Configuration section

## Configuration Guide

The compression level can now be configured via `config.toml`:

| Level | Description |
|-------|-------------|
| 0 | No compression (fastest) |
| 1 | Fast compression (default) |
| 6 | Balanced |
| 9 | Maximum compression (slowest) |

## Testing

The changes maintain backward compatibility - the default value (1) is equivalent to the previous `Compression::fast()` behavior.

Fixes #12